### PR TITLE
extra events for non-invites

### DIFF
--- a/callstate.go
+++ b/callstate.go
@@ -216,6 +216,7 @@ func (s CallState) TimeoutS() uint {
 
 type CallFlags uint8
 
+const CFNone CallFlags = 0
 const (
 	CFHashed          CallFlags = 1 << iota
 	CFReused                    // entry re-use instead of forking
@@ -229,6 +230,7 @@ const (
 
 // debugging, keep in sync with the CallFlags consts above
 var cfNames = [...]string{
+	"None",
 	"Entry_Hashed",
 	"Reused",
 	"REG_Reuse_Hack",

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/intuitivelabs/bytescase v1.0.1
-	github.com/intuitivelabs/counters v0.1.2-0.20210211203028-83443a9d590a
+	github.com/intuitivelabs/counters v0.1.2-0.20210216181413-f773d9188db7
 	github.com/intuitivelabs/sipsp v1.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,7 @@ github.com/intuitivelabs/bytescase v1.0.1 h1:As9FoZOyQuaQa4StsNHGlMbweAf3rZ5Ku2U
 github.com/intuitivelabs/bytescase v1.0.1/go.mod h1:Gr+B79bV8+mDKvYr4hja6qPVHtYG4Knem0K8gzZKHHU=
 github.com/intuitivelabs/counters v0.1.2-0.20210211203028-83443a9d590a h1:W5ezfdVuOurVjuj8e2MgZXnvwgC1Mghg1xraibjW9a4=
 github.com/intuitivelabs/counters v0.1.2-0.20210211203028-83443a9d590a/go.mod h1:gg2mPscHiatkLfDWF7bSuUeHcmsiTazGQx1pW62uJ0w=
+github.com/intuitivelabs/counters v0.1.2-0.20210216181413-f773d9188db7 h1:M8DerTOMNz/vq5vDmcbf6LSFGF2yQC4YdSeKzH6CKoI=
+github.com/intuitivelabs/counters v0.1.2-0.20210216181413-f773d9188db7/go.mod h1:gg2mPscHiatkLfDWF7bSuUeHcmsiTazGQx1pW62uJ0w=
 github.com/intuitivelabs/sipsp v1.0.1 h1:EjGSg+CH2Tf6GoXfRYnouvXe/5bVxxrjNUCD1o1H0X8=
 github.com/intuitivelabs/sipsp v1.0.1/go.mod h1:cQ5p5hsd+DeKu1XbCH7f7NN5wH2b8SOwuJBfk6VC0ms=

--- a/state_machine.go
+++ b/state_machine.go
@@ -602,18 +602,27 @@ func finalTimeoutEv(e *CallEntry) EventType {
 
 	// non INVs
 	case CallStFNonInv:
-		// nothing here. For REGISTERs we generate EvRegNew only on reply
+		// For REGISTERs we generate EvRegNew only on reply
 		// so if no reply seen, we won't generate an EvRegDel or EvRegExpired
+		// TODO: review  EvOtherTimeout for REGISTER, BYE, CANCEL
+		event = EvOtherTimeout
+		forcedStatus = 408
+		forcedReason = &timeoutReason
 	case CallStNonInvNegReply:
-		// we care only about REGISTERs timeouts and timeout after
-		// auth. failure at this point. TODO: SUBSCRIBE
+		//  TODO: SUBSCRIBE
 		if authFailure(e.ReplStatus[0]) || authFailure(e.ReplStatus[1]) {
 			event = EvAuthFailed
+		} else {
+			event = EvOtherFailed
 		}
 		// else if REGISTER, like above, do nothing
 	case CallStNonInvFinished:
 		if e.Method == sipsp.MRegister && !e.EvFlags.Test(EvRegDel) {
 			event = EvRegExpired
+		}
+		// for every non-inv that is not a REGISTER => EvOtherOk
+		if e.Method != sipsp.MRegister {
+			event = EvOtherOk
 		}
 
 	case CallStInit:


### PR DESCRIPTION
- support for:

   * other-failed : non-inv. failed (negative reply),  not covered
     by another event (e..g not auth-failed) and not part of an
     existing call

   * other-timeout: non-inv. timeout (no final reply received)

  * other-ok: non-inv finished with an ok reply (and not covered by
    other events like reg-*)

  (all are generated after retr. catching timeout)

- place-holders and basic event fill support for parse-error and
msg-probe